### PR TITLE
Support clang coverage profile 10, 9, 8

### DIFF
--- a/xen/Rules.mk
+++ b/xen/Rules.mk
@@ -135,7 +135,7 @@ $(filter %.init.o,$(obj-y) $(obj-bin-y) $(extra-y)): CFLAGS-y += -DINIT_SECTIONS
 non-init-objects = $(filter-out %.init.o, $(obj-y) $(obj-bin-y) $(extra-y))
 
 ifeq ($(CONFIG_CC_IS_CLANG),y)
-    cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping
+    cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping -fcoverage-mcdc
 else
     cov-cflags-$(CONFIG_COVERAGE) := -fprofile-arcs -ftest-coverage
     cov-cflags-$(CONFIG_CONDITION_COVERAGE) += -fcondition-coverage

--- a/xen/Rules.mk
+++ b/xen/Rules.mk
@@ -135,7 +135,13 @@ $(filter %.init.o,$(obj-y) $(obj-bin-y) $(extra-y)): CFLAGS-y += -DINIT_SECTIONS
 non-init-objects = $(filter-out %.init.o, $(obj-y) $(obj-bin-y) $(extra-y))
 
 ifeq ($(CONFIG_CC_IS_CLANG),y)
-    cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping -fcoverage-mcdc
+    CLANG_VERSION := $(shell $(CC) -dumpversion | cut -d. -f1)
+    CLANG_VERSION_GTE_18 := $(shell [ $(CLANG_VERSION) -ge 18 ] && echo y)
+    ifeq ($(CLANG_VERSION_GTE_18),y)
+        cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping -fcoverage-mcdc
+    else
+        cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping
+    endif
 else
     cov-cflags-$(CONFIG_COVERAGE) := -fprofile-arcs -ftest-coverage
     cov-cflags-$(CONFIG_CONDITION_COVERAGE) += -fcondition-coverage

--- a/xen/Rules.mk
+++ b/xen/Rules.mk
@@ -135,13 +135,7 @@ $(filter %.init.o,$(obj-y) $(obj-bin-y) $(extra-y)): CFLAGS-y += -DINIT_SECTIONS
 non-init-objects = $(filter-out %.init.o, $(obj-y) $(obj-bin-y) $(extra-y))
 
 ifeq ($(CONFIG_CC_IS_CLANG),y)
-    CLANG_VERSION := $(shell $(CC) -dumpversion | cut -d. -f1)
-    CLANG_VERSION_GTE_18 := $(shell [ $(CLANG_VERSION) -ge 18 ] && echo y)
-    ifeq ($(CLANG_VERSION_GTE_18),y)
-        cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping -fcoverage-mcdc
-    else
-        cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping
-    endif
+    cov-cflags-$(CONFIG_COVERAGE) := -fprofile-instr-generate -fcoverage-mapping
 else
     cov-cflags-$(CONFIG_COVERAGE) := -fprofile-arcs -ftest-coverage
     cov-cflags-$(CONFIG_CONDITION_COVERAGE) += -fcondition-coverage

--- a/xen/common/coverage/llvm.c
+++ b/xen/common/coverage/llvm.c
@@ -44,6 +44,58 @@
     ((uint64_t)'f' << 16) | ((uint64_t)'R' << 8)  | ((uint64_t)129)
 #endif
 
+#if __clang_major__ >= 19
+#define LLVM_PROFILE_VERSION    10
+#define LLVM_PROFILE_NUM_KINDS  3
+#elif __clang_major__ == 18
+#define LLVM_PROFILE_VERSION    9
+#define LLVM_PROFILE_NUM_KINDS  2
+#elif __clang_major__ >= 14 && __clang_major__ <= 17
+#define LLVM_PROFILE_VERSION    8
+#define LLVM_PROFILE_NUM_KINDS  2
+#else
+#error "Unsupported Clang version"
+#endif
+
+struct llvm_profile_data {
+    uint64_t name_ref;
+    uint64_t function_hash;
+    void *relative_counter;
+#if __clang_major__ >= 18
+    void *relative_bitmap;
+#endif
+    void *function;
+    void *values;
+    uint32_t nr_counters;
+    uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
+#if __clang_major__ >= 18
+    uint32_t numbitmap_bytes;
+#endif
+};
+
+struct llvm_profile_header {
+    uint64_t magic;
+    uint64_t version;
+    uint64_t binary_ids_size;
+    uint64_t num_data;
+    uint64_t padding_bytes_before_counters;
+    uint64_t num_counters;
+    uint64_t padding_bytes_after_counters;
+    uint64_t num_bitmap_bytes;
+    uint64_t padding_bytes_after_bitmap_bytes;
+    uint64_t names_size;
+#if __clang_major__ >= 18
+    uint64_t counters_delta;
+    uint64_t bitmap_delta;
+#endif
+    uint64_t names_delta;
+#if __clang_major__ >= 19
+    uint64_t num_vtables;
+    uint64_t vnames_size;
+#endif
+    uint64_t value_kind_last;
+};
+
 /*
  * Since Xen uses the llvm code coverage support without the run time library
  * __llvm_profile_runtime must be defined according to the docs at:
@@ -66,177 +118,6 @@ extern char __stop___llvm_prf_cnts[];
 #define START_COUNTERS  ((char *)__start___llvm_prf_cnts)
 #define END_COUNTERS    ((char *)__stop___llvm_prf_cnts)
 
-#if __clang_major__ >= 18
-extern char __start___llvm_prf_bits[];
-extern char __stop___llvm_prf_bits[];
-#define START_BITS      ((char *)__start___llvm_prf_bits)
-#define STOP_BITS       ((char *)__stop___llvm_prf_bits)
-#endif
-
-#if __clang_major__ >= 19
-#define LLVM_PROFILE_VERSION    10
-#define LLVM_PROFILE_NUM_KINDS  3
-
-struct llvm_profile_data {
-    uint64_t name_ref;
-    uint64_t function_hash;
-    void *relative_counter;
-    void *relative_bitmap;
-    void *function;
-    void *values;
-    uint32_t nr_counters;
-    uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
-    uint32_t numbitmap_bytes;
-};
-
-struct llvm_profile_header {
-    uint64_t magic;
-    uint64_t version;
-    uint64_t binary_ids_size;
-    uint64_t num_data;
-    uint64_t padding_bytes_before_counters;
-    uint64_t num_counters;
-    uint64_t padding_bytes_after_counters;
-    uint64_t num_bitmap_bytes;
-    uint64_t padding_bytes_after_bitmap_bytes;
-    uint64_t names_size;
-    uint64_t counters_delta;
-    uint64_t bitmap_delta;
-    uint64_t names_delta;
-    uint64_t num_vtables;
-    uint64_t vnames_size;
-    uint64_t value_kind_last;
-};
-
-struct llvm_vtable_profile_data {
-    uint64_t name_hash;
-    void* pointer;
-    uint32_t size;
-};
-
-struct llvm_profile_header get_header(void) {
-    return (struct llvm_profile_header) {
-        .magic = LLVM_PROFILE_MAGIC,
-        .version = LLVM_PROFILE_VERSION,
-        .binary_ids_size = 0,
-        .num_data = (((intptr_t)END_DATA + sizeof(struct llvm_profile_data) - 1)
-                - (intptr_t)START_DATA) / sizeof(struct llvm_profile_data),
-        .padding_bytes_before_counters = 0,
-        .num_counters = (((intptr_t)END_COUNTERS + sizeof(uint64_t) - 1)
-                - (intptr_t)START_COUNTERS) / sizeof(uint64_t),
-        .padding_bytes_after_counters = 0,
-        .num_bitmap_bytes = (uintptr_t)STOP_BITS - (uintptr_t)START_BITS,
-        .padding_bytes_after_bitmap_bytes = 0,
-        .names_size = (END_NAMES - START_NAMES) * sizeof(char),
-        .counters_delta = (uintptr_t)START_COUNTERS - (uintptr_t)START_DATA,
-        .bitmap_delta = (uintptr_t)START_BITS - (uintptr_t)START_DATA,
-        .names_delta = (uintptr_t)START_NAMES,
-        .num_vtables = 0,
-        .vnames_size = 0,
-        .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
-    };
-}
-
-#elif __clang_major__ == 18
-#define LLVM_PROFILE_VERSION    9
-#define LLVM_PROFILE_NUM_KINDS  2
-struct llvm_profile_data {
-    uint64_t name_ref;
-    uint64_t function_hash;
-    void *relative_counter;
-    void *relative_bitmap;
-    void *function;
-    void *values;
-    uint32_t nr_counters;
-    uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
-    uint32_t numbitmap_bytes;
-};
-
-struct llvm_profile_header {
-    uint64_t magic;
-    uint64_t version;
-    uint64_t binary_ids_size;
-    uint64_t num_data;
-    uint64_t padding_bytes_before_counters;
-    uint64_t num_counters;
-    uint64_t padding_bytes_after_counters;
-    uint64_t num_bitmap_bytes;
-    uint64_t padding_bytes_after_bitmap_bytes;
-    uint64_t names_size;
-    uint64_t counters_delta;
-    uint64_t bitmap_delta;
-    uint64_t names_delta;
-    uint64_t value_kind_last;
-};
-
-struct llvm_profile_header get_header(void) {
-    return (struct llvm_profile_header) {
-        .magic = LLVM_PROFILE_MAGIC,
-        .version = LLVM_PROFILE_VERSION,
-        .binary_ids_size = 0,
-        .num_data = (((intptr_t)END_DATA + sizeof(struct llvm_profile_data) - 1)
-                - (intptr_t)START_DATA) / sizeof(struct llvm_profile_data),
-        .padding_bytes_before_counters = 0,
-        .num_counters = (((intptr_t)END_COUNTERS + sizeof(uint64_t) - 1)
-                - (intptr_t)START_COUNTERS) / sizeof(uint64_t),
-        .padding_bytes_after_counters = 0,
-        .num_bitmap_bytes = (uintptr_t)STOP_BITS - (uintptr_t)START_BITS,
-        .padding_bytes_after_bitmap_bytes = 0,
-        .names_size = (END_NAMES - START_NAMES) * sizeof(char),
-        .counters_delta = (uintptr_t)START_COUNTERS - (uintptr_t)START_DATA,
-        .bitmap_delta = (uintptr_t)START_BITS - (uintptr_t)START_DATA,
-        .names_delta = (uintptr_t)START_NAMES,
-        .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
-    };
-}
-
-#elif __clang_major__ >= 14 && __clang_major__ <= 17
-#define LLVM_PROFILE_VERSION    8
-#define LLVM_PROFILE_NUM_KINDS  2
-struct llvm_profile_data {
-    uint64_t name_ref;
-    uint64_t function_hash;
-    void *relative_counter;
-    void *function;
-    void *values;
-    uint32_t nr_counters;
-    uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
-};
-
-struct llvm_profile_header {
-    uint64_t magic;
-    uint64_t version;
-    uint64_t binary_ids_size;
-    uint64_t data_size;
-    uint64_t padding_bytes_before_counters;
-    uint64_t counter_size;
-    uint64_t padding_bytes_after_counters;
-    uint64_t names_size;
-    uint64_t counters_delta;
-    uint64_t names_delta;
-    uint64_t value_kind_last;
-};
-
-struct llvm_profile_header get_header(void) {
-    return (struct llvm_profile_header) {
-        .magic = LLVM_PROFILE_MAGIC,
-        .version = LLVM_PROFILE_VERSION,
-        .binary_ids_size = 0,
-        .data_size = (((intptr_t)END_DATA + sizeof(struct llvm_profile_data) - 1)
-                - (intptr_t)START_DATA) / sizeof(struct llvm_profile_data),
-        .padding_bytes_before_counters = 0,
-        .counter_size = (((intptr_t)END_COUNTERS + sizeof(uint64_t) - 1)
-                - (intptr_t)START_COUNTERS) / sizeof(uint64_t),
-        .padding_bytes_after_counters = 0,
-        .names_size = (END_NAMES - START_NAMES) * sizeof(char),
-        .counters_delta = (uintptr_t)START_COUNTERS - (uintptr_t)START_DATA,
-        .names_delta = (uintptr_t)START_NAMES,
-        .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
-    };
-}
-#else
-#error "Unsupported Clang version"
-#endif
 
 static void cf_check reset_counters(void)
 {
@@ -252,7 +133,21 @@ static uint32_t cf_check get_size(void)
 static int cf_check dump(
     XEN_GUEST_HANDLE_PARAM(char) buffer, uint32_t *buf_size)
 {
-    struct llvm_profile_header header = get_header();
+    struct llvm_profile_header header = {
+        .magic = LLVM_PROFILE_MAGIC,
+        .version = LLVM_PROFILE_VERSION,
+        .binary_ids_size = 0,
+        .num_data = (((intptr_t)END_DATA + sizeof(struct llvm_profile_data) - 1)
+                - (intptr_t)START_DATA) / sizeof(struct llvm_profile_data),
+        .padding_bytes_before_counters = 0,
+        .num_counters = (((intptr_t)END_COUNTERS + sizeof(uint64_t) - 1)
+                - (intptr_t)START_COUNTERS) / sizeof(uint64_t),
+        .padding_bytes_after_counters = 0,
+        .names_size = (END_NAMES - START_NAMES) * sizeof(char),
+        .counters_delta = (uintptr_t)START_COUNTERS - (uintptr_t)START_DATA,
+        .names_delta = (uintptr_t)START_NAMES,
+        .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
+    };
     unsigned int off = 0;
 
 #define APPEND_TO_BUFFER(src, size)                             \

--- a/xen/common/coverage/llvm.c
+++ b/xen/common/coverage/llvm.c
@@ -50,7 +50,7 @@
 #elif __clang_major__ == 18
 #define LLVM_PROFILE_VERSION    9
 #define LLVM_PROFILE_NUM_KINDS  2
-#elif __clang_major__ >= 14 && __clang_major__ <= 17
+#elif __clang_major__ >= 14
 #define LLVM_PROFILE_VERSION    8
 #define LLVM_PROFILE_NUM_KINDS  2
 #else
@@ -60,12 +60,12 @@
 struct llvm_profile_data {
     uint64_t name_ref;
     uint64_t function_hash;
-    void *relative_counter;
+    intptr_t *relative_counter;
 #if __clang_major__ >= 18
-    void *relative_bitmap;
+    intptr_t *relative_bitmap;
 #endif
-    void *function;
-    void *values;
+    intptr_t *function;
+    intptr_t *values;
     uint32_t nr_counters;
     uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
 #if __clang_major__ >= 18
@@ -100,7 +100,7 @@ struct llvm_profile_header {
  * Since Xen uses the llvm code coverage support without the run time library
  * __llvm_profile_runtime must be defined according to the docs at:
  *
- * https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
+ * https://clang.llvm.org/docs/SourceBasedCodeCoverage.html 
  */
 int __llvm_profile_runtime;
 

--- a/xen/common/coverage/llvm.c
+++ b/xen/common/coverage/llvm.c
@@ -252,14 +252,7 @@ static uint32_t cf_check get_size(void)
 static int cf_check dump(
     XEN_GUEST_HANDLE_PARAM(char) buffer, uint32_t *buf_size)
 {
-    struct llvm_profile_header header = {
-        .magic = LLVM_PROFILE_MAGIC,
-        .version = LLVM_PROFILE_VERSION,
-        .names_size = END_NAMES - START_NAMES,
-        .counters_delta = (uintptr_t)(START_COUNTERS - START_DATA),
-        .names_delta = (uintptr_t)START_NAMES,
-        .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
-    };
+    struct llvm_profile_header header = get_header();
     unsigned int off = 0;
 
 #define APPEND_TO_BUFFER(src, size)                             \

--- a/xen/include/xen/types.h
+++ b/xen/include/xen/types.h
@@ -18,6 +18,7 @@ typedef signed long ssize_t;
 
 typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef __UINTPTR_TYPE__ uintptr_t;
+typedef __INTPTR_TYPE__ intptr_t;
 
 /*
  * Users of this macro are expected to pass a positive value.


### PR DESCRIPTION

- Added clang coverage profile 10, 9, 8.
- initialize llvm_profile_header for all versions based on llvm source code in `compiler-rt/include/profile/InstrProfData.inc` for each version.
- On X86 I test Xen hypervisor code coverage using Clang instrumentation on a Debian 12 (Bookworm) system. Xen was compiled from source with coverage enabled, installed, and booted in Dom0. Coverage data was extracted using xencov and compared against expected metrics from gcov
- On ARM I test it using qemu and follow this instructions: in [here](https://github.com/erkaii/xen-qemu-setup?tab=readme-ov-file)

Example of coverage output on ARM:
[cov.zip](https://github.com/user-attachments/files/22629528/cov.zip)