### PR TITLE
Support LLVM raw profile versions 5, 6, 7, 8, 9, and 10

### DIFF
--- a/xen/arch/x86/xen.lds.S
+++ b/xen/arch/x86/xen.lds.S
@@ -186,6 +186,8 @@ SECTIONS
   } PHDR(note) PHDR(text)
 #endif
 
+  LLVM_COV_RO_DATA
+
   _erodata = .;
 
   . = ALIGN(SECTION_ALIGN);
@@ -323,6 +325,8 @@ SECTIONS
        *(.data .data.*)
   } PHDR(text)
 
+  LLVM_COV_RW_DATA
+
   DECL_SECTION(.bss) {
        __bss_start = .;
        *(.bss.page_aligned*)
@@ -356,6 +360,8 @@ SECTIONS
 #endif
 
   DWARF2_DEBUG_SECTIONS
+
+  LLVM_COV_DEBUG
 
 #ifdef CONFIG_HYPERV_GUEST
   hv_hcall_page = ABSOLUTE(HV_HCALL_PAGE - XEN_VIRT_START + __XEN_VIRT_START);

--- a/xen/common/coverage/llvm.c
+++ b/xen/common/coverage/llvm.c
@@ -44,27 +44,65 @@
     ((uint64_t)'f' << 16) | ((uint64_t)'R' << 8)  | ((uint64_t)129)
 #endif
 
-#define LLVM_PROFILE_VERSION    4
+#if __clang_major__ >= 19 && __clang_major__ <= 20
+#define LLVM_PROFILE_VERSION    10
+#define LLVM_PROFILE_NUM_KINDS  3
+#elif __clang_major__ == 18
+#define LLVM_PROFILE_VERSION    9
 #define LLVM_PROFILE_NUM_KINDS  2
+#elif __clang_major__ >= 14
+#define LLVM_PROFILE_VERSION    8
+#define LLVM_PROFILE_NUM_KINDS  2
+#elif __clang_major__ == 13
+#define LLVM_PROFILE_VERSION    7
+#define LLVM_PROFILE_NUM_KINDS  2
+#elif __clang_major__ >= 11
+#define LLVM_PROFILE_VERSION    5
+#define LLVM_PROFILE_NUM_KINDS  2
+#else
+#error "LLVM coverage selected but an unsupported clang version is used"
+#endif
 
 struct llvm_profile_data {
     uint64_t name_ref;
     uint64_t function_hash;
-    void *counter;
+    void *relative_counter;
+#if __clang_major__ >= 18
+    void *relative_bitmap;
+#endif
     void *function;
     void *values;
     uint32_t nr_counters;
     uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
+#if __clang_major__ >= 18
+    uint32_t numbitmap_bytes;
+#endif
 };
 
 struct llvm_profile_header {
     uint64_t magic;
     uint64_t version;
-    uint64_t data_size;
-    uint64_t counters_size;
+#if __clang_major__ >= 13
+    uint64_t binary_ids_size;
+#endif
+    uint64_t num_data;
+    uint64_t padding_bytes_before_counters;
+    uint64_t num_counters;
+    uint64_t padding_bytes_after_counters;
+#if __clang_major__ >= 18
+    uint64_t num_bitmap_bytes;
+    uint64_t padding_bytes_after_bitmap_bytes;
+#endif
     uint64_t names_size;
     uint64_t counters_delta;
+#if __clang_major__ >= 18
+    uint64_t bitmap_delta;
+#endif
     uint64_t names_delta;
+#if __clang_major__ >= 19 && __clang_major__ <= 20
+    uint64_t num_vtables;
+    uint64_t vnames_size;
+#endif
     uint64_t value_kind_last;
 };
 
@@ -107,11 +145,34 @@ static int cf_check dump(
     struct llvm_profile_header header = {
         .magic = LLVM_PROFILE_MAGIC,
         .version = LLVM_PROFILE_VERSION,
-        .data_size = (END_DATA - START_DATA) / sizeof(struct llvm_profile_data),
-        .counters_size = (END_COUNTERS - START_COUNTERS) / sizeof(uint64_t),
+#if __clang_major__ >= 13
+        .binary_ids_size = 0,
+#endif
+        .num_data = ((END_DATA + sizeof(struct llvm_profile_data) - 1)
+                - START_DATA) / sizeof(struct llvm_profile_data),
+        .padding_bytes_before_counters = 0,
+        .num_counters = ((END_COUNTERS + sizeof(uint64_t) - 1)
+                - START_COUNTERS) / sizeof(uint64_t),
+        .padding_bytes_after_counters = 0,
+#if __clang_major__ >= 18
+        .num_bitmap_bytes = 0,
+        .padding_bytes_after_bitmap_bytes = 0,
+#endif
         .names_size = END_NAMES - START_NAMES,
+#if __clang_major__ >= 14
+        .counters_delta = START_COUNTERS - START_DATA,
+#else
         .counters_delta = (uintptr_t)START_COUNTERS,
+#endif
+
+#if __clang_major__ >= 18
+        .bitmap_delta = 0,
+#endif
         .names_delta = (uintptr_t)START_NAMES,
+#if __clang_major__ >= 19 && __clang_major__ <= 20
+        .num_vtables = 0,
+        .vnames_size = 0,
+#endif
         .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
     };
     unsigned int off = 0;

--- a/xen/common/coverage/llvm.c
+++ b/xen/common/coverage/llvm.c
@@ -67,14 +67,14 @@ struct llvm_profile_data {
     uint64_t name_ref;
     uint64_t function_hash;
     void *relative_counter;
-#if __clang_major__ >= 18
+#if LLVM_PROFILE_VERSION >= 9
     void *relative_bitmap;
 #endif
     void *function;
     void *values;
     uint32_t nr_counters;
     uint16_t nr_value_sites[LLVM_PROFILE_NUM_KINDS];
-#if __clang_major__ >= 18
+#if LLVM_PROFILE_VERSION >= 9
     uint32_t numbitmap_bytes;
 #endif
 };
@@ -82,24 +82,24 @@ struct llvm_profile_data {
 struct llvm_profile_header {
     uint64_t magic;
     uint64_t version;
-#if __clang_major__ >= 13
+#if LLVM_PROFILE_VERSION >= 7
     uint64_t binary_ids_size;
 #endif
     uint64_t num_data;
     uint64_t padding_bytes_before_counters;
     uint64_t num_counters;
     uint64_t padding_bytes_after_counters;
-#if __clang_major__ >= 18
+#if LLVM_PROFILE_VERSION >= 9
     uint64_t num_bitmap_bytes;
     uint64_t padding_bytes_after_bitmap_bytes;
 #endif
     uint64_t names_size;
     uint64_t counters_delta;
-#if __clang_major__ >= 18
+#if LLVM_PROFILE_VERSION >= 9
     uint64_t bitmap_delta;
 #endif
     uint64_t names_delta;
-#if __clang_major__ >= 19 && __clang_major__ <= 20
+#if LLVM_PROFILE_VERSION == 10
     uint64_t num_vtables;
     uint64_t vnames_size;
 #endif
@@ -145,34 +145,15 @@ static int cf_check dump(
     struct llvm_profile_header header = {
         .magic = LLVM_PROFILE_MAGIC,
         .version = LLVM_PROFILE_VERSION,
-#if __clang_major__ >= 13
-        .binary_ids_size = 0,
-#endif
-        .num_data = ((END_DATA + sizeof(struct llvm_profile_data) - 1)
-                - START_DATA) / sizeof(struct llvm_profile_data),
-        .padding_bytes_before_counters = 0,
-        .num_counters = ((END_COUNTERS + sizeof(uint64_t) - 1)
-                - START_COUNTERS) / sizeof(uint64_t),
-        .padding_bytes_after_counters = 0,
-#if __clang_major__ >= 18
-        .num_bitmap_bytes = 0,
-        .padding_bytes_after_bitmap_bytes = 0,
-#endif
+        .num_data = DIV_ROUND_UP(END_DATA - START_DATA, sizeof(uint64_t)),
+        .num_counters = DIV_ROUND_UP(END_COUNTERS - START_COUNTERS, sizeof(uint64_t)),
         .names_size = END_NAMES - START_NAMES,
-#if __clang_major__ >= 14
+#if LLVM_PROFILE_VERSION >= 8
         .counters_delta = START_COUNTERS - START_DATA,
 #else
         .counters_delta = (uintptr_t)START_COUNTERS,
 #endif
-
-#if __clang_major__ >= 18
-        .bitmap_delta = 0,
-#endif
         .names_delta = (uintptr_t)START_NAMES,
-#if __clang_major__ >= 19 && __clang_major__ <= 20
-        .num_vtables = 0,
-        .vnames_size = 0,
-#endif
         .value_kind_last = LLVM_PROFILE_NUM_KINDS - 1,
     };
     unsigned int off = 0;

--- a/xen/include/xen/xen.lds.h
+++ b/xen/include/xen/xen.lds.h
@@ -81,6 +81,24 @@
   .stab.index 0 : { *(.stab.index) }         \
   .stab.indexstr 0 : { *(.stab.indexstr) }
 
+#if defined(CONFIG_COVERAGE) && defined(CONFIG_CC_IS_CLANG)
+
+#define LLVM_COV_RW_DATA                                   \
+    DECL_SECTION(__llvm_prf_cnts) { *(__llvm_prf_cnts) }   \
+    DECL_SECTION(__llvm_prf_data) { *(__llvm_prf_data) }   \
+    DECL_SECTION(__llvm_prf_bits) { *(__llvm_prf_bits) }
+
+#define LLVM_COV_RO_DATA                                   \
+    DECL_SECTION(__llvm_prf_names) { *(__llvm_prf_names) }
+
+#define LLVM_COV_DEBUG                                     \
+    DECL_DEBUG(__llvm_covfun, 8)                           \
+    DECL_DEBUG(__llvm_covmap, 8)
+#else
+#define LLVM_COV_RW_DATA
+#define LLVM_COV_RO_DATA
+#define LLVM_COV_DEBUG
+#endif
 /*
  * ELF sections.
  *


### PR DESCRIPTION
From d1f8ba2fadd0d58490614e02123a0846af36bc30 Mon Sep 17 00:00:00 2001
Message-ID: <d1f8ba2fadd0d58490614e02123a0846af36bc30.1761226762.git.samaan.dehghan@gmail.com>
From: Saman Dehghan <samaan.dehghan@gmail.com>
To: xen-devel@lists.xenproject.org
Cc: Jan Beulich <jbeulich@suse.com>
Cc: Andrew Cooper <andrew.cooper3@citrix.com>
Cc: "Roger Pau Monné" <roger.pau@citrix.com>
Cc: Anthony PERARD <anthony.perard@vates.tech>
Cc: Michal Orzel <michal.orzel@amd.com>
Cc: Julien Grall <julien@xen.org>
Cc: Stefano Stabellini <sstabellini@kernel.org>
Date: Thu, 23 Oct 2025 08:37:28 -0500
Subject: [PATCH v3] Support LLVM raw profile versions 5, 6, 7, 8, 9, and 10

This change enables compatibility for measuring code coverage
with Clang versions 14 through 20 by supporting their
respective raw profile formats.

1- Added support for LLVM raw profile versions 5, 6, 7, 8, 9, and 10
2- Initialized llvm_profile_header for all versions based on llvm source code in 
   `compiler-rt/include/profile/InstrProfData.inc` for each version.
3- We tested this patch for all Clang versions from 11 through 20 on both ARM and X86 platform.
4- Fixed linking warnings related to coverage code in X86

Signed-off-by: Saman Dehghan <samaan.dehghan@gmail.com>